### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dependency Status](http://img.shields.io/gemnasium/flexik/kosapi_client.svg)][gemnasium]
 [![Code Climate](http://img.shields.io/codeclimate/github/flexik/kosapi_client.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/codeclimate/coverage/github/flexik/kosapi_client.svg)][codeclimate]
+[![Inline docs](http://inch-pages.github.io/github/flexik/kosapi_client.svg)](http://inch-pages.github.io/github/flexik/kosapi_client)
 
 [travis]: http://travis-ci.org/flexik/kosapi_client
 [gemnasium]: https://gemnasium.com/flexik/kosapi_client


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/flexik/kosapi_client.png)

Your status page for this project is http://inch-pages.github.io/github/flexik/kosapi_client

Thanks for giving this a shot!
