### PR TITLE
Faraday 0.9 compatibility (vcr source from master)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kosapi_client.gemspec
 gemspec
+
+group :development do
+  gem 'vcr', github: 'vcr/vcr', branch: 'master'
+end

--- a/kosapi_client.gemspec
+++ b/kosapi_client.gemspec
@@ -23,14 +23,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-given'
   spec.add_development_dependency 'dotenv'
-  spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fuubar', '~> 2.0.0.rc1'
 
   spec.add_runtime_dependency 'oauth2'
-  spec.add_runtime_dependency 'faraday', '~> 0.8.9' # VCR does not work with newer versions yet
+  spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'escape_utils' unless RUBY_PLATFORM == 'java' # used for uri_template
   spec.add_runtime_dependency 'uri_template'


### PR DESCRIPTION
separate branch for this issue.

IMHO the fault is on vcr's side. The fix was merged to master in October 2014, but no tagged version was released since September 2014.

I've found a workaround in moving the vcr from _kosapi_client.gemspec_ to _Gemfile_ and use master branch (maybe lock commit sha) as `gem 'vcr', github: 'vcr/vcr', branch: 'master'`. It's not a nice one, but once again isn't vcr just a development (testing) dependency?

https://github.com/cvut/kosapi_client.rb/pull/8#issuecomment-77344432