### PR TITLE
fix date require

### DIFF
--- a/lib/kosapi_client/entity/exam.rb
+++ b/lib/kosapi_client/entity/exam.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module KOSapiClient
   module Entity
     class Exam < BaseEntity


### PR DESCRIPTION
Not sure why it doesn't fail on travis, but on local I can't run the tests without the `require` statement.